### PR TITLE
Add basics for supporing multiple langauges

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,9 +19,20 @@
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
+[[projects]]
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/tag",
+    "language",
+    "unicode/cldr"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dbc03d7c9dd4e54b6993c8ece59c3174becb58bd828e500cf8ad825e340278c4"
+  inputs-digest = "51bcb76c63e409236dc6e95f44f66afac84fdbdbd8ab368afe2a414e6efaaa26"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/xkcdpwd/main.go
+++ b/cmd/xkcdpwd/main.go
@@ -71,6 +71,7 @@ type Xkcdpwd struct {
 func (x *Xkcdpwd) Run() int {
 	var (
 		// flags
+		lang        string
 		separator   string
 		showVersion bool
 	)
@@ -80,6 +81,7 @@ func (x *Xkcdpwd) Run() int {
 	_ = flags.Bool("v", false, "be more verbose")
 
 	// register global flags
+	flags.StringVar(&lang, "lang", "", "language to use, a valid IETF language tag (default: en)")
 	flags.StringVar(&separator, "separator", " ", "passphrase separator")
 	flags.BoolVar(&showVersion, "version", false, "show version information")
 
@@ -110,7 +112,12 @@ func (x *Xkcdpwd) Run() int {
 		return errorExitCode
 	}
 
-	d := dict.GetDict("en")
+	// Source lang from the environment, but prefer the command line if set
+	if envLang, ok := os.LookupEnv("LANG"); ok && lang == "" {
+		lang = envLang
+	}
+	d := dict.GetDict(lang)
+
 	l := big.NewInt(int64(d.Length() - 1))
 	words := make([]string, 4, 4)
 	for i := 0; i < 10; i++ {

--- a/cmd/xkcdpwd/testdata/help/long/stderr.txt
+++ b/cmd/xkcdpwd/testdata/help/long/stderr.txt
@@ -4,6 +4,7 @@ xkcdpwd is a passphrase generator based on XKCD comic #936
 
 Flags:
 
+  -lang       language to use, a valid IETF language tag (default: en)
   -separator  passphrase separator (default:  )
   -v          be more verbose (default: false)
   -version    show version information (default: false)

--- a/cmd/xkcdpwd/testdata/help/short/stderr.txt
+++ b/cmd/xkcdpwd/testdata/help/short/stderr.txt
@@ -4,6 +4,7 @@ xkcdpwd is a passphrase generator based on XKCD comic #936
 
 Flags:
 
+  -lang       language to use, a valid IETF language tag (default: en)
   -separator  passphrase separator (default:  )
   -v          be more verbose (default: false)
   -version    show version information (default: false)

--- a/dictionary.go
+++ b/dictionary.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"strings"
 
+	"golang.org/x/text/language"
+
 	"github.com/wfscheper/xkcdpwd/internal/langs"
 )
 
@@ -32,7 +34,7 @@ type Dictionary struct {
 
 // Length returns the number of words in the Dictionary.
 func (d *Dictionary) Length() int {
-	if d.length == nil {
+	if d.length == nil && d.words != nil {
 		l := len(d.words)
 		d.length = &l
 	}
@@ -73,10 +75,15 @@ func NewDictionary(r io.Reader) *Dictionary {
 	return d
 }
 
+var matcher = language.NewMatcher([]language.Tag{
+	language.English,
+})
+
 // GetDict returns the dictionary associated with the language code lang.
 func GetDict(lang string) *Dictionary {
-	switch lang {
-	case "en":
+	tag, _ := language.MatchStrings(matcher, lang)
+	switch tag {
+	case language.English:
 		data := langs.MustAsset("languages/en")
 		return NewDictionary(bytes.NewBuffer(data))
 	default:

--- a/dictionary_test.go
+++ b/dictionary_test.go
@@ -104,6 +104,12 @@ func TestWord(t *testing.T) {
 func TestGetDict(t *testing.T) {
 	is := assert.New(t)
 	d := GetDict("en")
-	is.Equal(d.Word(0), "able")
-	is.Nil(GetDict("foo"))
+	if is.NotNil(d) {
+		is.Equal(d.Word(0), "able")
+	}
+	// matcher will try *really* hard to give a match
+	d = GetDict("foo")
+	if is.NotNil(d) {
+		is.Equal(d.Word(0), "able")
+	}
 }


### PR DESCRIPTION
While POSIX locale strings aren't exactly the same as IETF lanauge tags,
they're close enough for now and the golang language matcher is pretty
forgiving.

Fixes #7